### PR TITLE
Fix SMTP sending for implicit TLS on port 465.

### DIFF
--- a/mail_util.py
+++ b/mail_util.py
@@ -17,12 +17,20 @@ def send_email(subject, body, config: SmtpConfig, logger: Logging):
     message['To'] = config.recipients#['smtp']['recipients']  # Set current recipient
     # Send the email
     try:
-        # Create an SMTP object and specify the server and the port
-        with smtplib.SMTP(config.server, config.port) as server:
-            server.starttls()  # Start TLS encryption
-            server.login(config.login, config.password)  # Log in to the SMTP server
-            server.send_message(message)  # Send the email
-            logger.log(f"Email sent successfully to {config.recipients}!")
+        context = ssl.create_default_context()
+        if config.port == 465:
+            with smtplib.SMTP_SSL(config.server, config.port, context=context) as server:
+                server.login(config.login, config.password)
+                server.send_message(message)
+        else:
+            with smtplib.SMTP(config.server, config.port) as server:
+                server.ehlo()
+                server.starttls(context=context)
+                server.ehlo()
+                server.login(config.login, config.password)
+                server.send_message(message)
+
+        logger.log(f"Email sent successfully to {config.recipients}!")
     except Exception as e:
         logger.error(f"Error sending email to {config.recipients}: {e}")
 

--- a/mail_util.py
+++ b/mail_util.py
@@ -1,4 +1,5 @@
 import smtplib
+import ssl
 import yaml
 from email.message import EmailMessage
 from log_util import Logging


### PR DESCRIPTION
I run the autobackup on bare metal, and email notifications were not being sent. In the log I saw this error message:

`2026-05-22 10:50:01 - UDEV-Trigger - ERROR - Error sending email to ['XXXXXXX@XXXXXXXX']: Connection unexpectedly closed`

The mail sender previously used `smtplib.SMTP(...)+starttls()` for all ports. This breaks on SMTP servers that expect implicit TLS on port 465, where the connection must be encrypted from the start. In Python, that should be handled with `smtplib.SMTP_SSL(...)` instead of plain `SMTP(...).starttls()`

This change uses `SMTP_SSL` for port 465 and keeps `SMTP + STARTTLS` for other ports.